### PR TITLE
Fixed parse bug

### DIFF
--- a/sudoku.lisp
+++ b/sudoku.lisp
@@ -246,7 +246,7 @@
   (with-slots (grid values) puzzle
     ;; fill in the grid
     (loop
-       for index below 80
+       for index below 81
        for digit = (parse-integer grid-string :start index :end (+ 1 index) :junk-allowed t)
        do (setf (row-major-aref grid index) (or digit 0)))
     ;; now assign the values


### PR DESCRIPTION
Thank you for the excellent port of Peter Norvig's sudoku solver.

While reading through the code to understand it, I found a minor bug that causes the last entry in a sudoku puzzle string to not be read.  It doesn't matter for the vast majority of puzzles, but theoretically it can cause a determined puzzle to become under-determined, so I posted this in an act of pathological perfectionism!